### PR TITLE
fix: RPi with DSI turns off with media

### DIFF
--- a/screensaver.py
+++ b/screensaver.py
@@ -326,7 +326,9 @@ def run():
     from xbmc import getCondVisibility
 
     # If player has media, avoid running
-    if getCondVisibility("Player.HasMedia"):
+    # Exception for method 8 (DSI Display on Raspberry)
+    display_method = int(get_setting('display_method', 0))
+    if getCondVisibility("Player.HasMedia") and display_method != 8:
         log(1, 'Screensaver not started because player has media.')
         return
 


### PR DESCRIPTION
This patch enables the turn off of an DSI-screen only.
It makes more sense to run an KODI mediacenter with radio streams this way.
Display turns suddenly on if you touch it.

If you play videos it will not turn off screen
If you set "Use Visuals for Music" it will not turn off music screen